### PR TITLE
use local setup value

### DIFF
--- a/lib/App/test/travis.pm
+++ b/lib/App/test/travis.pm
@@ -137,7 +137,7 @@ sub run {
         $config->{$mode} //= $behavior->{$mode};
     }
 
-    $behavior->{setup}->($config, $tempdir, sub {
+    $setup->($config, $tempdir, sub {
         my $versions = $config->{$language} // []; # TODO
 
         # http://about.travis-ci.org/docs/user/build-configuration/#Build-Lifecycle


### PR DESCRIPTION
Hi,

In except _node_js_ or _perl_, it does not execute.
I wanted to fix this by #4.

```
$ test-travis
# running .travis.yml
Use of uninitialized value in subroutine entry at /Users/hattori-h/.cpanm/lib/perl5/App/test/travis.pm line 167.
Can't use string ("") as a subroutine ref while "strict refs" in use at /Users/hattori-h/.cpanm/lib/perl5/App/test/travis.pm line 167.
```

Thanks.
